### PR TITLE
scrollInstantly should always fully render.

### DIFF
--- a/fast-list.js
+++ b/fast-list.js
@@ -154,7 +154,7 @@ FastList.prototype = {
    * to skip rendering altogether (busy).
    *
    */
-  updateRenderingWindow: function() {
+  updateRenderingWindow: function(instant) {
     var geo = this.geometry;
 
     var position = this.els.container.scrollTop;
@@ -186,7 +186,7 @@ FastList.prototype = {
       (this.source.getFullHeight() - geo.viewportHeight);
 
     // Full stop, forcefuly idle
-    if (onTop || atBottom) {
+    if (onTop || atBottom || instant) {
       geo.busy = false;
       geo.idle = true;
       return;
@@ -406,7 +406,7 @@ FastList.prototype = {
 
   scrollInstantly: function(position) {
     this.els.container.scrollTop = position;
-    this.updateRenderingWindow();
+    this.updateRenderingWindow(true);
     this.render();
   },
 

--- a/test/fast-list-test.js
+++ b/test/fast-list-test.js
@@ -377,15 +377,21 @@ suite('FastList >', function() {
     setup(function() {
       fastList = new FastList(source);
       scheduler.mutation.yield();
+
+      // We want the geometry to have been updated at least once for the
+      // test to be reallistic
+      container.scrollTop = 1;
+      scheduler.attachDirect.yield();
     });
 
-    test('it updates the rendering directly', function() {
+    test('it updates the rendering directly, with details', function() {
       fastList.scrollInstantly(1200);
       assertCurrentlyRenderedWindow({
         container: container,
         source: source,
         from: 15,
-        to: 34
+        to: 34,
+        expectsDetail: true
       });
     });
 


### PR DESCRIPTION
This is the first part of #76, will think about the "full stop by taping" a bit more.
